### PR TITLE
Get ReShade info from Github

### DIFF
--- a/reshade-installer.pl
+++ b/reshade-installer.pl
@@ -13,12 +13,12 @@ $userAgent->agent("reshade-on-unix/0.1");
 $userAgent->show_progress(1);
 
 sub reShadeVersion {
-    my $req = HTTP::Request->new(GET => "https://reshade.me");
+    my $req = HTTP::Request->new(GET => "https://api.github.com/repos/crosire/reshade/tags");
     my $response = $userAgent->request($req);
     $response->is_success or die $response->status_line;
-    my ($version) = $response->decoded_content =~ /ReShade_Setup_([\d.]+)\.exe/
+    my ($version) = $response->decoded_content =~ /v([\d.]+)/ 
         or die "Could not extract version info";
-    return $version
+    return $version;
 }
 
 sub downloadFile {


### PR DESCRIPTION
Retrieves version info from the GitHub API so that the installer script continues working even when reshade.me is down.

I spoke with crosire and they mentioned that downloads at reshade.me/downloads/ should continue to work even when the main website is down (I'm assuming this is because files are served via the webserver instead of the webapp).

It's still using regex to pull out the version info from the response as the macOS Perl doesn't seem to ship JSON-Parse by default.